### PR TITLE
Abhishek - This changes the two files that then allow for navbar swagger turn on.

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,7 +9,6 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-#app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,11 +9,13 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+#app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 
 spring.liquibase.url=jdbc:h2:file:./target/db-development
 spring.liquibase.user=sa

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,7 +3,6 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
-# next line adds to UIlink
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 spring.liquibase.url=${JDBC_DATABASE_URL}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,6 +3,8 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+# next line adds to UIlink
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}


### PR DESCRIPTION
As a developer I can easily turn on the swagger option on the app navbar for any deployment through defining an environment variable SHOW_SWAGGER_UI_LINK so that it is easy to access swagger when I need it, but I can easily turn it off when I don't. Allows developer to set a variable called SHOW_SWAGGER_UI_LINK to true or false in their config variables. Adding these couple of lines on the application files allows for the swagger option on the navbar. Now, based on the dokku config value being true or false, it will give a swagger option. 

This closes #6. 
<img width="963" alt="Screen Shot 2024-05-21 at 6 58 50 PM" src="https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/114532302/545ae75e-714b-4086-a7b1-3f05fb02f3d0">
Above is when swagger is set to true on dokku.
<img width="918" alt="Screen Shot 2024-05-21 at 7 01 45 PM" src="https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/114532302/b5c611bc-8355-4ba2-b802-5b5694ada4a9">
Above is when swagger is set to false on dokku.
