### PR TITLE
Abhishek - H2 Console

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,7 +8,8 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
+#spring.h2.console.enabled=true
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
 #app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,9 +8,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-#spring.h2.console.enabled=true
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
-#app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -5,6 +5,8 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 # next line adds to UIlink
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+#next line adds the H2 console option
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
 
 spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,9 +3,7 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
-# next line adds to UIlink
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
-#next line adds the H2 console option
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
 
 spring.liquibase.url=${JDBC_DATABASE_URL}


### PR DESCRIPTION
This closes #11
As a developer I can easily turn on the H2 option on the app navbar for any deployment through defining an environment variable H2 so that it is easy to access swagger when I need it, but I can easily turn it off when I don't. Allows developer to set a variable called H2 to true or false in their config variables. Adding these couple of lines on the application files allows for the H2 option on the navbar. Now, based on the dokku config value being true or false, it will give a H2 option.
<img width="911" alt="Screen Shot 2024-05-22 at 2 16 58 AM" src="https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/114532302/6772995a-aac2-4098-8566-8773b017f263">
Above is when dokku config H2 is set to true.
<img width="869" alt="Screen Shot 2024-05-22 at 2 23 36 AM" src="https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/114532302/503d8d8d-7c4d-417e-af8c-5fff73497c0e">
Above is when dokku config H2 is set to false.