### PR TITLE
Created Prefix matching, Autocomplete, and typing mode for dropdown menu

### DIFF
--- a/frontend/src/main/components/OurAddDropdownForm.js
+++ b/frontend/src/main/components/OurAddDropdownForm.js
@@ -146,7 +146,6 @@ export default function OurAddDropdownForm({
     };
 
     const internalOnChange = (event) => {
-        // Stryker disable next-line all : the form element disables onChange if autocomplete is false
         if(autocomplete){
             // grab the userText 
             const newSelectedContent = event.target.value;
@@ -179,7 +178,7 @@ export default function OurAddDropdownForm({
                         data-testid={`${testId}-test-dropdown-form`}
                         type="text"
                         value={autocomplete ? userTypedContent : (selectedContent !== null ? selectedContent.label : "") }
-                        onChange={autocomplete ? internalOnChange : null}
+                        onChange={internalOnChange}
                         style={validationStyle}
                         onFocus={() => {
                             changeShowingDropdown(true);

--- a/frontend/src/main/components/OurAddDropdownForm.js
+++ b/frontend/src/main/components/OurAddDropdownForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useState } from 'react';
 import { Form } from 'react-bootstrap';
 
-function DropdownOption({ label, isSelected, onClickFunc, testid, rawKey }) {
+function DropdownOption({ label, isSelected, onClickFunc, testid, rawKey, isGhost }) {
     const [isHovered, setIsHovered] = useState(false);
     const handleMouseEnter = () => {
         setIsHovered(true);
@@ -13,7 +13,7 @@ function DropdownOption({ label, isSelected, onClickFunc, testid, rawKey }) {
     // Stryker disable all
     const divStyle = {
         backgroundColor: isHovered ? 'lightgreen' : 'white',
-        transition: 'backgroundColor 0.25s ease',
+        transition: 'background-color 0.25s ease',
         'paddingLeft': '2px',
         'paddingRight': '2px',
         'cursor': 'pointer',
@@ -21,11 +21,15 @@ function DropdownOption({ label, isSelected, onClickFunc, testid, rawKey }) {
     // Stryker restore all
     let mainOption;
     if (!isSelected) {
+        let altStyle = divStyle;
+        if(isGhost){
+            altStyle['backgroundColor'] = 'lightgreen';
+        }
         mainOption = (
             <div
                 key={rawKey}
                 data-testid={testid}
-                style={divStyle}
+                style={altStyle}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
                 onClick={onClickFunc}
@@ -66,9 +70,24 @@ export default function OurAddDropdownForm({
         return 0;
     });
     // Stryker restore all
-    
+
+    // if there is already a selection as the form is created, filter the content so that the dropdown will 
+    // only show options that have a matching prefix
+    // if basis is undefined, then all content should be render
+    const fixedContent = [];
+    for(let i = 0; i < content.length; ++i){
+        if(!basis || content[i].label.startsWith(basis.label)){
+            fixedContent.push(content[i]);
+        }
+    }
     const [selectedContent, changeSelectedContent] = useState(basis);
+    const [userTypedContent, changeUserTypContent] = useState(basis ? basis.label : "");
     const [showingDropdown, changeShowingDropdown] = useState(false);
+    const [filteredContent, changeFilteredContent] = useState(fixedContent);
+    const [validationStyle, changeValidationStyle] = useState({});
+    // the user can press enter to autocomplete
+    // Stryker disable next-line all : there might be a good test for this but since showingDropdown doesn't render anything on fixedContent.length === 0 this might be harder to test
+    const [ghostContent, changeGhostContent] = useState(fixedContent.length > 0 ? fixedContent[0] : null);
 
     // Stryker disable all
     const optionWrapperStyle = {
@@ -82,12 +101,72 @@ export default function OurAddDropdownForm({
     // Stryker restore all
 
     let count = 0;
+    const filterPrefix = (prefix) => {
+        // filter the dropdown to only have the matching prefix options
+        const prefixedContent = [];
+        let isValidSelection = false;
+        let overflow = true;
+        let first = true;
+
+        for(let i = 0; i < content.length; ++i){
+            if(content[i].label.startsWith(prefix)){
+                overflow = false;
+                // the first element will be "semihovered" i.e. the user can press enter
+                // autofill the text automatically
+                if(first){
+                    changeGhostContent(content[i]);
+                    first = false;
+                }
+
+                // a direct match is found
+                // NOTE: THIS ASSUMES THAT ALL CONTENT IS UNIQUE
+                if(content[i].label === prefix){
+                    changeSelectedContent(content[i]);
+                    isValidSelection = true;
+                }
+
+                prefixedContent.push(content[i]);
+            }
+        }
+        // if there was no direct match then there is no selectedContent
+        if(!isValidSelection){
+            changeSelectedContent(null);
+        } 
+        // no matches or prefix matches
+        if(overflow){
+            changeValidationStyle({color:"red"});
+            changeGhostContent(null);
+        } else {
+            changeValidationStyle({});
+        }
+
+        changeFilteredContent(prefixedContent);
+
+    };
 
     const internalOnChange = (event) => {
+        // grab the userText 
+        const newSelectedContent = event.target.value;
+        changeUserTypContent(newSelectedContent);
+
+        filterPrefix(newSelectedContent);
+
         if (onChangeFunc) {
             onChangeFunc(event);
         }
     };
+
+    const fillGhost = (event) => {
+        if(event.key === "Enter" && ghostContent !== null) {
+            
+            changeUserTypContent(ghostContent.label);
+            filterPrefix(ghostContent.label);
+            changeShowingDropdown(false);
+        } else {
+            changeShowingDropdown(true);
+        }
+    };
+
     return (
         <div>
             {label}
@@ -96,20 +175,28 @@ export default function OurAddDropdownForm({
                     <Form.Control
                         data-testid={`${testId}-test-dropdown-form`}
                         type="text"
-                        value={selectedContent ? selectedContent.label : ''}
+                        value={userTypedContent}
                         onChange={internalOnChange}
-                        onSelect={() => {
+                        style={validationStyle}
+                        onFocus={() => {
                             changeShowingDropdown(true);
                         }}
+                        onClick={() => {
+                            changeShowingDropdown(true);
+                        }}
+                        onKeyDown={fillGhost}
                     />
                     {showingDropdown && (
                         <div data-testid = {`${testId}-wrapper`} style={optionWrapperStyle}>
-                            {content.map((obj) => {
+                            {filteredContent.map((obj) => {
                                 const key = obj.key;
-                     
                                 const innerLabel = obj.label;
                                 const select = () => {
                                     changeSelectedContent(obj);
+                                    changeUserTypContent(innerLabel);
+                                    changeGhostContent(obj);
+
+                                    filterPrefix(innerLabel);
                                     changeShowingDropdown(false);
                                 };
                                 return (
@@ -120,6 +207,7 @@ export default function OurAddDropdownForm({
                                             selectedContent &&
                                             key === selectedContent.key
                                         }
+                                        isGhost={key === ghostContent.key}
                                         rawKey = {key}
                                         // Stryker disable next-line all
                                         key ={`${key}-dropdown-option`}

--- a/frontend/src/stories/components/OurAddDropdownForm.stories.js
+++ b/frontend/src/stories/components/OurAddDropdownForm.stories.js
@@ -50,3 +50,23 @@ TenSchoolRender.args = {
     testId : "test-sample-dropdown",
     label : "Sample Ten Dropdown",
 }
+
+export const OneSchoolRenderNoAuto = Template.bind({});
+
+OneSchoolRenderNoAuto.args = {
+    basis: null,
+    content: schoolsListFixtures.oneSchool,
+    testId : "test-sample-dropdown",
+    label : "Sample One Dropdown",
+    autocomplete : false,
+};
+
+export const TenSchoolRenderNoAuto = Template.bind({});
+
+TenSchoolRenderNoAuto.args = {
+    basis: schoolsListFixtures.tenSchool[1],
+    content: schoolsListFixtures.tenSchool,
+    testId : "test-sample-dropdown",
+    label : "Sample Ten Dropdown",
+    autocomplete : false,
+}

--- a/frontend/src/tests/components/OurAddDropdownForm.test.js
+++ b/frontend/src/tests/components/OurAddDropdownForm.test.js
@@ -15,6 +15,11 @@ describe('OurAddDropdownForm Tests', () => {
         { label: 'a', key: 'a1' },
         { label: 'a', key: 'a2' },   
     ];
+    const subsetThreeOptions = [
+        { label: 'ab', key: 'ab' },
+        { label: 'abba', key: 'abba' },
+        { label: 'abba concert', key: 'abba concert' },
+    ];
 
     test('renders an empty dropdown element without crashing', () => {
         render(
@@ -53,9 +58,9 @@ describe('OurAddDropdownForm Tests', () => {
         fireEvent.select(submitField);
         // verify that initial selection is highlighted
         expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
-        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "white"});
-        expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor: "green"});
-        expect(await screen.findByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor: "white"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "green"});
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
     });
 
     test('renders on no inital selected element', async () => {
@@ -174,12 +179,13 @@ describe('OurAddDropdownForm Tests', () => {
         const selectOption = screen.getByTestId('testid-dropdown-form-option-1');
 
         fireEvent.click(selectOption);
-        fireEvent.select(submitField);
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        fireEvent.click(submitField);
 
         expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
-        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "white"});
-        expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor: "green"});
-        expect(await screen.findByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor: "white"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "green"});
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
     });
 
     test("selection color changes over hovering", async () => {
@@ -198,12 +204,12 @@ describe('OurAddDropdownForm Tests', () => {
         const selectOption = screen.getByTestId('testid-dropdown-form-option-2');
         fireEvent.mouseOver(selectOption);
 
-        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "white"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "lightgreen"}); // ghost
         expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor: "white"});
         expect(await screen.findByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor: "lightgreen"});
 
         fireEvent.mouseOut(selectOption);
-        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "white"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "lightgreen"}); // ghost
         expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor: "white"});
         expect(await screen.findByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor: "white"});
     });
@@ -218,6 +224,7 @@ describe('OurAddDropdownForm Tests', () => {
         expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveTextContent("b");
         expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveTextContent("c");
     });
+
 
     test("same label options are rendered", async () => {
         render(<OurAddDropdownForm content={sameTwoOptions} label="empty" />);
@@ -236,5 +243,232 @@ describe('OurAddDropdownForm Tests', () => {
         expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
         expect(screen.getByTestId('testid-test-dropdown-form')).toHaveAttribute("disabled");
         expect(screen.getByTestId('testid-test-dropdown-form')).toHaveStyle({"cursor" : "not-allowed"});
-    })
+    });
+
+    test("prefix renders only a portion of options", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'c'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(await screen.findByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("choose me");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("click me");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"lightgreen"}); // ghost
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix renders only a portion of options 2", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'p'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("pick me");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"lightgreen"});
+    });
+
+    test("prefix renders only a portion of options with an initial selection", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty" basis={subsetThreeOptions[1]}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"green"});
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba concert");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix renders only a portion of options with an initial selection 2", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty" basis={subsetThreeOptions[0]}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("ab");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"green"});
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix renders only a portion of options 3", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty"/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'a'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("a");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"lightgreen"});
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix renders only a portion of options after changing prefix and the initialElement is no longer selected", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty" basis={subsetThreeOptions[0]}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("ab");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"green"});
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor:"white"});
+
+        fireEvent.change(submitField, { target: { value : 'a'} });
+        fireEvent.click(submitField); // select doesn't work for some reason?
+
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("ab");
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"lightgreen"});
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix removes all options and causes red text", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'cheese'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-0')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(submitField).toHaveStyle({color:"red"});
+    });
+
+    test("red text removed on proper prefix", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'cheese'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-0')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(submitField).toHaveStyle({color:"red"});
+
+        fireEvent.change(submitField, { target: { value : 'choose'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
+
+        expect(submitField).not.toHaveStyle({color:"red"});
+    });
+
+    test("enter autocompletes and chooses first selection", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'choose'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        fireEvent.keyDown(submitField, {key: 'Enter', code: 'Enter'});
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        expect(submitField).toHaveAttribute("value", "choose me");
+        expect(screen.queryByTestId('testid-wrapper')).not.toBeInTheDocument();
+    });
+
+    test("dropdown still shows on keyboard input aside from Enter", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : ''} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        fireEvent.keyDown(submitField, {key: 'c', code: 'c'});
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+    });
+
+    test("dropdown still shows on autocomplete attempt with no valid options", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'I SEE FIRE'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        fireEvent.keyDown(submitField, {key: 'Enter', code: 'Enter'});
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+    });
+
+    test("dropdown rerenders after autocomplete and nonEnterKey", async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.change(submitField, { target: { value : 'c'} });
+        fireEvent.select(submitField);
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        fireEvent.keyDown(submitField, {key: 'Enter', code: 'Enter'});
+
+        expect(screen.queryByTestId('testid-wrapper')).not.toBeInTheDocument();
+        fireEvent.keyDown(submitField, {key: 'Esc', code: 'Esc'});
+
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+    });
+
 });

--- a/frontend/src/tests/components/OurAddDropdownForm.test.js
+++ b/frontend/src/tests/components/OurAddDropdownForm.test.js
@@ -292,7 +292,7 @@ describe('OurAddDropdownForm Tests', () => {
     });
 
     test("prefix renders only a portion of options", async () => {
-        render(<OurAddDropdownForm content={threeOptions} label="empty" />);
+        render(<OurAddDropdownForm content={threeOptions} label="empty" autocomplete={true}/>);
 
         expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
         const submitField = screen.getByTestId('testid-test-dropdown-form');
@@ -321,6 +321,22 @@ describe('OurAddDropdownForm Tests', () => {
         const firstSelection = screen.getByTestId('testid-dropdown-form-option-2');
         fireEvent.click(firstSelection);
         fireEvent.click(submitField);
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("a");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
+    });
+
+    test("prefix doesn't renders only a portion of options with autocomplete off 2", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty" autocomplete={false}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        // load in the options
+        fireEvent.select(submitField);
+        expect(await screen.findByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+        // trigger onChange which user can't normally do?
+        fireEvent.change(submitField, {target : {value : "abba"}});
 
         expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("a");
         expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");

--- a/frontend/src/tests/components/OurAddDropdownForm.test.js
+++ b/frontend/src/tests/components/OurAddDropdownForm.test.js
@@ -63,6 +63,44 @@ describe('OurAddDropdownForm Tests', () => {
         expect(screen.queryByTestId('testid-dropdown-form-option-2')).not.toBeInTheDocument();
     });
 
+    test('renders an correctly selected initialElement with autocomplete off', async () => {
+        render(
+            <OurAddDropdownForm
+                content={threeOptions}
+                label="empty"
+                basis={threeOptions[1]}
+                autocomplete={false}
+            />
+        );
+        // load in element
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        // verify that there is an initial selection
+        expect(screen.queryByTestId('testid-test-dropdown-form')).toHaveAttribute('value', 'click me');
+        // load dropdown
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        fireEvent.select(submitField);
+        // verify that initial selection is highlighted
+        expect(await screen.findByTestId('testid-wrapper')).toBeInTheDocument();
+        expect(await screen.findByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor: "white"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor: "green"});
+        expect(await screen.findByTestId('testid-dropdown-form-option-2')).toHaveStyle({backgroundColor: "white"});
+    });
+
+    test('correctly css styling on autocomplete being off', async () => {
+        render(
+            <OurAddDropdownForm
+                content={threeOptions}
+                label="empty"
+                basis={threeOptions[1]}
+                autocomplete={false}
+            />
+        );
+        // load in element
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        expect(screen.getByTestId('testid-test-dropdown-form')).toHaveStyle({cursor: 'pointer', 'caretColor': 'transparent'});
+    });
+
+
     test('renders on no inital selected element', async () => {
         render(<OurAddDropdownForm content={threeOptions} label="empty" />);
 
@@ -77,6 +115,14 @@ describe('OurAddDropdownForm Tests', () => {
         expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
 
         expect(screen.queryByTestId('testid-dropdown-form-option-0')).not.toBeInTheDocument();
+    });
+
+    test('renders empty text with autocomplete off', async () => {
+        render(<OurAddDropdownForm content={threeOptions} label="empty" autocomplete={false}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        
+        expect(screen.getByTestId('testid-test-dropdown-form')).toHaveValue("");
     });
 
     test('default testid is testId', async () => {
@@ -261,6 +307,24 @@ describe('OurAddDropdownForm Tests', () => {
         expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("click me");
         expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveStyle({backgroundColor:"lightgreen"}); // ghost
         expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveStyle({backgroundColor:"white"});
+    });
+
+    test("prefix doesn't renders only a portion of options with autocomplete off", async () => {
+        render(<OurAddDropdownForm content={subsetThreeOptions} label="empty" autocomplete={false}/>);
+
+        expect(await screen.findByTestId('testid-test-dropdown-form')).toBeInTheDocument();
+        const submitField = screen.getByTestId('testid-test-dropdown-form');
+        // load in the options
+        fireEvent.select(submitField);
+        expect(await screen.findByTestId('testid-dropdown-form-option-2')).toBeInTheDocument();
+        // select last one
+        const firstSelection = screen.getByTestId('testid-dropdown-form-option-2');
+        fireEvent.click(firstSelection);
+        fireEvent.click(submitField);
+
+        expect(screen.getByTestId('testid-dropdown-form-option-0')).toHaveTextContent("a");
+        expect(screen.getByTestId('testid-dropdown-form-option-1')).toHaveTextContent("abba");
+        expect(screen.getByTestId('testid-dropdown-form-option-2')).toHaveTextContent("abba concert");
     });
 
     test("prefix renders only a portion of options 2", async () => {


### PR DESCRIPTION
This PR stems off PR #32 and uses the branch off branch (the file changed contains files from the previous pull request)

### Changes

---

In this PR we updated the generic dropdown menu to (optionally) allow the User to 

1. type in the content they want (in addition to selecting from a dropdown)
2. autocomplete their query by pressing `Enter`
3. minimise their search by limiting the shown content to only those with a matching prefix

As a User I can type and see whether or not my query is invalid:
![invalid](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/53740464/bc2d86f9-985d-4163-bec3-fdcbb2ced151)

As a user I can limit my query through prefixes:
![dropdownprefixsimple](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/53740464/5607af4e-3b2e-42d5-9674-a1394e0e9405)

As a user I can finish my dropdown selection with Enter:
![autocomplete](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/53740464/7ed554dd-084d-46e7-bb36-63f8e5d7eb10)

As a developer I can still enable the old dropdown without the new features with `autocomplete={false}`
![dropdownautocompleteoptional](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-2/assets/53740464/2f2e08de-5c04-4f59-91f5-0b2c6e26e28c)


[Link to storybook](https://ucsb-cs156-s24.github.io/proj-organic-s24-5pm-2/prs/35/storybook/?path=/story/components-ouradddropdownform--ten-school-render)

### Issues


---

Partially closes #2 
Closes #34 


### Notes

---


