### PR TITLE
Nico Backend Controller Modified for Frontend Changes to School Instantiation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -112,25 +112,11 @@ public class SchoolController extends ApiController{
   @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public School postSchool(
-        @Parameter(name="abbrev", description="university domain name", example="ucsb") @RequestParam String abbrev,
-        @Parameter(name="name", description="University name") @RequestParam String name,
-        @Parameter(name="termRegex", description="Format: Example [WSMF]\\d\\d") @RequestParam String termRegex,
-        @Parameter(name="termDescription", description="Enter quarter, e.g. F23, W24, S24, M24") @RequestParam String termDescription,
-        @Parameter(name="termError", description="input error?") @RequestParam String termError)
-        {
+        @Parameter(name = "school", description="school in json format") @RequestBody School school
+        )
+    {
 
-        School school = School.builder().build();
-        school.setAbbrev(abbrev);
-        school.setName(name);
-        school.setTermRegex(termRegex);
-        school.setTermDescription(termDescription);
-        school.setTermError(termError);
-
-        if (!termDescription.matches(school.getTermRegex())) {
-            throw new IllegalArgumentException("Invalid termDescription format. It must follow the pattern " + school.getTermRegex());
-        }
-
-        if (!abbrev.equals(abbrev.toLowerCase())){
+        if (!school.getAbbrev().equals(school.getAbbrev().toLowerCase())){
             throw new IllegalArgumentException("Invalid abbrev format. Abbrev must be all lowercase");
         }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -112,25 +112,10 @@ public class SchoolController extends ApiController{
   @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public School postSchool(
-        @Parameter(name="abbrev", description="university domain name", example="ucsb") @RequestParam String abbrev,
-        @Parameter(name="name", description="University name") @RequestParam String name,
-        @Parameter(name="termRegex", description="Format: Example [WSMF]\\d\\d") @RequestParam String termRegex,
-        @Parameter(name="termDescription", description="Enter quarter, e.g. F23, W24, S24, M24") @RequestParam String termDescription,
-        @Parameter(name="termError", description="input error?") @RequestParam String termError)
-        {
+        @Parameter(name="school", description="school in json format") @RequestBody School school 
+    ){
 
-        School school = School.builder().build();
-        school.setAbbrev(abbrev);
-        school.setName(name);
-        school.setTermRegex(termRegex);
-        school.setTermDescription(termDescription);
-        school.setTermError(termError);
-
-        if (!termDescription.matches(school.getTermRegex())) {
-            throw new IllegalArgumentException("Invalid termDescription format. It must follow the pattern " + school.getTermRegex());
-        }
-
-        if (!abbrev.equals(abbrev.toLowerCase())){
+        if (!school.getAbbrev().equals(school.getAbbrev().toLowerCase())){
             throw new IllegalArgumentException("Invalid abbrev format. Abbrev must be all lowercase");
         }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -116,7 +116,6 @@ public class SchoolController extends ApiController{
     ){
 
         if (!school.getAbbrev().equals(school.getAbbrev().toLowerCase())){
-        if (!school.getAbbrev().equals(school.getAbbrev().toLowerCase())){
             throw new IllegalArgumentException("Invalid abbrev format. Abbrev must be all lowercase");
         }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -113,8 +113,8 @@ public class SchoolController extends ApiController{
     @PostMapping("/post")
     public School postSchool(
         @Parameter(name = "school", description="school in json format") @RequestBody School school
-        )
-    {
+    )
+        {
 
         if (!school.getAbbrev().equals(school.getAbbrev().toLowerCase())){
             throw new IllegalArgumentException("Invalid abbrev format. Abbrev must be all lowercase");

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -247,7 +247,7 @@ public class SchoolControllerTests extends ControllerTestCase{
 
 
             School school1 = School.builder()
-                            .abbrev("UCSB")
+                            .abbrev("ucsb")
                             .name("University of California Santa Barbara")
                             .termRegex("W")
                             .termDescription("W24")
@@ -255,20 +255,20 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .build();
                             
 
-            when(schoolRepository.findById(eq("UCSB"))).thenReturn(Optional.of(school1));
+            when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.of(school1));
 
             // act
             MvcResult response = mockMvc.perform(
-                            delete("/api/schools?abbrev=UCSB")
+                            delete("/api/schools?abbrev=ucsb")
                                             .with(csrf()))
                             .andExpect(status().isOk()).andReturn();
 
             // assert
-            verify(schoolRepository, times(1)).findById("UCSB");
+            verify(schoolRepository, times(1)).findById("ucsb");
             verify(schoolRepository, times(1)).delete(any());
 
             Map<String, Object> json = responseToJson(response);
-            assertEquals("School with id UCSB deleted", json.get("message"));
+            assertEquals("School with id ucsb deleted", json.get("message"));
         }
 
         @WithMockUser(roles = { "ADMIN", "USER" })
@@ -277,18 +277,18 @@ public class SchoolControllerTests extends ControllerTestCase{
                         throws Exception {
                 // arrange
 
-                when(schoolRepository.findById(eq("UCSB"))).thenReturn(Optional.empty());
+                when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.empty());
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/schools?abbrev=UCSB")
+                                delete("/api/schools?abbrev=ucsb")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
-                verify(schoolRepository, times(1)).findById("UCSB");
+                verify(schoolRepository, times(1)).findById("ucsb");
                 Map<String, Object> json = responseToJson(response);
-                assertEquals("School with id UCSB not found", json.get("message"));
+                assertEquals("School with id ucsb not found", json.get("message"));
         }
 
     
@@ -320,53 +320,25 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termDescription("F24")
                             .termError("error")
                             .build();
-
+            String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
             // act
             MvcResult response = mockMvc.perform(
-                post("/api/schools/post?abbrev=ucsb&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=F24&termError=error")
-                                .with(csrf()))
+                post("/api/schools/post")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8")
+                            .content(requestBody)
+                            .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
                 
 
             // assert
             verify(schoolRepository, times(1)).save(school);
-            String expectedJson = mapper.writeValueAsString(school);
             String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
+            assertEquals(requestBody, responseString);
             }
-
-    
-    @WithMockUser(roles = { "ADMIN", "USER" })
-    @Test
-    public void an_admin_user_can_post_a_new_school_bad_format_termRegex() throws Exception {
-            // arrange
-
-            School school = School.builder()
-                            .abbrev("ucsb")
-                            .name("Ubarbara")
-                            .termRegex("[WSMF]\\d\\d")
-                            .termDescription("q24")
-                            .termError("error")
-                            .build();
-
-            when(schoolRepository.save(eq(school))).thenReturn(school);  
-
-
-            // act
-            MvcResult response = mockMvc.perform(post("/api/schools/post?abbrev=UCSB&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=q24&termError=error")
-                                                                .with(csrf()))
-                            .andExpect(status().is(400)).andReturn(); // only admins can post
-                
-
-            // assert
-            Map<String, Object> json = responseToJson(response);
-            assertEquals("IllegalArgumentException", json.get("type"));
-            assertEquals("Invalid termDescription format. It must follow the pattern [WSMF]\\d\\d", json.get("message"));            
-            }
-
     
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
@@ -380,13 +352,16 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termDescription("F24")
                             .termError("error")
                             .build();
-
+            String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
             // act
-            MvcResult response = mockMvc.perform(post("/api/schools/post?abbrev=UCSB&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=F24&termError=error")
-                                                                .with(csrf()))
+            MvcResult response = mockMvc.perform(post("/api/schools/post")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8")
+                            .content(requestBody)
+                            .with(csrf()))
                             .andExpect(status().is(400)).andReturn(); // only admins can post
                 
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -1,3 +1,4 @@
+
 package edu.ucsb.cs156.organic.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -319,7 +320,6 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termDescription("F24")
                             .termError("error")
                             .build();
-
             String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
@@ -352,17 +352,16 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termDescription("F24")
                             .termError("error")
                             .build();
-
             String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
             // act
             MvcResult response = mockMvc.perform(post("/api/schools/post")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8")
+                            .content(requestBody))
                             .andExpect(status().is(400)).andReturn(); // only admins can post
                 
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -257,22 +257,18 @@ public class SchoolControllerTests extends ControllerTestCase{
                             
 
             when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.of(school1));
-            when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.of(school1));
 
             // act
             MvcResult response = mockMvc.perform(
-                            delete("/api/schools?abbrev=ucsb")
                             delete("/api/schools?abbrev=ucsb")
                                             .with(csrf()))
                             .andExpect(status().isOk()).andReturn();
 
             // assert
             verify(schoolRepository, times(1)).findById("ucsb");
-            verify(schoolRepository, times(1)).findById("ucsb");
             verify(schoolRepository, times(1)).delete(any());
 
             Map<String, Object> json = responseToJson(response);
-            assertEquals("School with id ucsb deleted", json.get("message"));
             assertEquals("School with id ucsb deleted", json.get("message"));
         }
 
@@ -283,20 +279,16 @@ public class SchoolControllerTests extends ControllerTestCase{
                 // arrange
 
                 when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.empty());
-                when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.empty());
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/schools?abbrev=ucsb")
                                 delete("/api/schools?abbrev=ucsb")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
                 verify(schoolRepository, times(1)).findById("ucsb");
-                verify(schoolRepository, times(1)).findById("ucsb");
                 Map<String, Object> json = responseToJson(response);
-                assertEquals("School with id ucsb not found", json.get("message"));
                 assertEquals("School with id ucsb not found", json.get("message"));
         }
 
@@ -330,7 +322,6 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termError("error")
                             .build();
             String requestBody = objectMapper.writeValueAsString(school);
-            String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
@@ -348,7 +339,6 @@ public class SchoolControllerTests extends ControllerTestCase{
             verify(schoolRepository, times(1)).save(school);
             String responseString = response.getResponse().getContentAsString();
             assertEquals(requestBody, responseString);
-            assertEquals(requestBody, responseString);
             }
     
     
@@ -358,13 +348,12 @@ public class SchoolControllerTests extends ControllerTestCase{
             // arrange
 
             School school = School.builder()
-                            .abbrev("ucsb")
+                            .abbrev("UCSB")
                             .name("Ubarbara")
                             .termRegex("[WSMF]\\d\\d")
                             .termDescription("F24")
                             .termError("error")
                             .build();
-            String requestBody = objectMapper.writeValueAsString(school);
             String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -1,4 +1,3 @@
-
 package edu.ucsb.cs156.organic.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -247,7 +246,7 @@ public class SchoolControllerTests extends ControllerTestCase{
 
 
             School school1 = School.builder()
-                            .abbrev("UCSB")
+                            .abbrev("ucsb")
                             .name("University of California Santa Barbara")
                             .termRegex("W")
                             .termDescription("W24")
@@ -255,20 +254,20 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .build();
                             
 
-            when(schoolRepository.findById(eq("UCSB"))).thenReturn(Optional.of(school1));
+            when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.of(school1));
 
             // act
             MvcResult response = mockMvc.perform(
-                            delete("/api/schools?abbrev=UCSB")
+                            delete("/api/schools?abbrev=ucsb")
                                             .with(csrf()))
                             .andExpect(status().isOk()).andReturn();
 
             // assert
-            verify(schoolRepository, times(1)).findById("UCSB");
+            verify(schoolRepository, times(1)).findById("ucsb");
             verify(schoolRepository, times(1)).delete(any());
 
             Map<String, Object> json = responseToJson(response);
-            assertEquals("School with id UCSB deleted", json.get("message"));
+            assertEquals("School with id ucsb deleted", json.get("message"));
         }
 
         @WithMockUser(roles = { "ADMIN", "USER" })
@@ -277,18 +276,18 @@ public class SchoolControllerTests extends ControllerTestCase{
                         throws Exception {
                 // arrange
 
-                when(schoolRepository.findById(eq("UCSB"))).thenReturn(Optional.empty());
+                when(schoolRepository.findById(eq("ucsb"))).thenReturn(Optional.empty());
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/schools?abbrev=UCSB")
+                                delete("/api/schools?abbrev=ucsb")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
-                verify(schoolRepository, times(1)).findById("UCSB");
+                verify(schoolRepository, times(1)).findById("ucsb");
                 Map<String, Object> json = responseToJson(response);
-                assertEquals("School with id UCSB not found", json.get("message"));
+                assertEquals("School with id ucsb not found", json.get("message"));
         }
 
     
@@ -321,52 +320,25 @@ public class SchoolControllerTests extends ControllerTestCase{
                             .termError("error")
                             .build();
 
+            String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
             // act
             MvcResult response = mockMvc.perform(
-                post("/api/schools/post?abbrev=ucsb&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=F24&termError=error")
-                                .with(csrf()))
+                post("/api/schools/post")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody))
                 .andExpect(status().isOk()).andReturn();
                 
 
             // assert
             verify(schoolRepository, times(1)).save(school);
-            String expectedJson = mapper.writeValueAsString(school);
             String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
+            assertEquals(requestBody, responseString);
             }
-
-    
-    @WithMockUser(roles = { "ADMIN", "USER" })
-    @Test
-    public void an_admin_user_can_post_a_new_school_bad_format_termRegex() throws Exception {
-            // arrange
-
-            School school = School.builder()
-                            .abbrev("ucsb")
-                            .name("Ubarbara")
-                            .termRegex("[WSMF]\\d\\d")
-                            .termDescription("q24")
-                            .termError("error")
-                            .build();
-
-            when(schoolRepository.save(eq(school))).thenReturn(school);  
-
-
-            // act
-            MvcResult response = mockMvc.perform(post("/api/schools/post?abbrev=UCSB&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=q24&termError=error")
-                                                                .with(csrf()))
-                            .andExpect(status().is(400)).andReturn(); // only admins can post
-                
-
-            // assert
-            Map<String, Object> json = responseToJson(response);
-            assertEquals("IllegalArgumentException", json.get("type"));
-            assertEquals("Invalid termDescription format. It must follow the pattern [WSMF]\\d\\d", json.get("message"));            
-            }
-
     
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
@@ -374,19 +346,23 @@ public class SchoolControllerTests extends ControllerTestCase{
             // arrange
 
             School school = School.builder()
-                            .abbrev("UCSB")
+                            .abbrev("ucsb")
                             .name("Ubarbara")
                             .termRegex("[WSMF]\\d\\d")
                             .termDescription("F24")
                             .termError("error")
                             .build();
 
+            String requestBody = objectMapper.writeValueAsString(school);
             when(schoolRepository.save(eq(school))).thenReturn(school);  
 
 
             // act
-            MvcResult response = mockMvc.perform(post("/api/schools/post?abbrev=UCSB&name=Ubarbara&termRegex=[WSMF]\\d\\d&termDescription=F24&termError=error")
-                                                                .with(csrf()))
+            MvcResult response = mockMvc.perform(post("/api/schools/post")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody))
                             .andExpect(status().is(400)).andReturn(); // only admins can post
                 
 


### PR DESCRIPTION
In this PR, changes were made to SchoolController and SchoolControllerTests to allow for school to be created using 'data' rather than 'params'. These edits had to be made before moving on to the frontend side. 