### PR TITLE
Nico - Setup Edit Button to take User to School Edit Page

### DIFF
--- a/frontend/src/main/pages/SchoolEditPage.js
+++ b/frontend/src/main/pages/SchoolEditPage.js
@@ -1,0 +1,70 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import SchoolForm from "main/components/School/SchoolForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function SchoolEditPage({storybook=false}) {
+  let { abbrev } = useParams();
+
+  const { data: school, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/schools?abbrev=${abbrev}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/schools`,
+        params: {
+          abbrev
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (school) => ({
+    url: "/api/schools/update",
+    method: "PUT",
+    params: {
+      abbrev: school.abbrev,
+    },
+    data: {
+      name: school.name,
+      termRegex: school.termRegex,
+      termDescription: school.termDescription,
+      termError: school.termError
+    }
+  });
+
+  const onSuccess = (school) => {
+    toast(`School Updated - abbrev: ${school.abbrev} name: ${school.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/schools?abbrev=${abbrev}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/schools" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit School</h1>
+        {
+          school && <SchoolForm initialContents={school} submitAction={onSubmit} buttonLabel="Update" />
+        }
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/SchoolEditPage.test.js
+++ b/frontend/src/tests/pages/SchoolEditPage.test.js
@@ -1,0 +1,187 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import SchoolEditPage from "main/pages/SchoolEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            abbrev: "ucsb"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("SchoolEditPage tests", () => {
+
+    describe("when the backend doesn't return data", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/schools", { params: { abbrev: "ucsb" } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <SchoolEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit School");
+            expect(screen.queryByTestId("SchoolForm-name")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/schools", { params: { abbrev: "ucsb" } }).reply(200, {
+                abbrev: "ucsb",
+                name: "UC Santa Barbara",
+                termRegex: "[WSMF]\\d\\d",
+                termDescription: "S24",
+                termError: "Error 1" 
+            });
+            axiosMock.onPut('/api/schools/update').reply(200, {
+                abbrev: "ucsb",
+                name: "UC Santa Barbara 2",
+                termRegex: "[WSMF]\\e\\e",
+                termDescription: "W24",
+                termError: "Error 2" 
+            });
+        });
+
+        const queryClient = new QueryClient();
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <SchoolEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByTestId("SchoolForm-abbrev");
+
+            const abbrevField = screen.getByTestId("SchoolForm-abbrev");
+            const nameField = screen.getByTestId("SchoolForm-name");
+            const termRegexField = screen.getByTestId("SchoolForm-termRegex");
+            const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
+            const termErrorField = screen.getByTestId("SchoolForm-termError");
+            const submitButton = screen.getByTestId("SchoolForm-submit");
+
+            expect(abbrevField).toBeInTheDocument();
+            expect(abbrevField).toHaveValue("ucsb");
+            expect(nameField).toBeInTheDocument();
+            expect(nameField).toHaveValue("UC Santa Barbara");
+            expect(termRegexField).toBeInTheDocument();
+            expect(termRegexField).toHaveValue("[WSMF]\\d\\d");
+            expect(termDescriptionField).toBeInTheDocument();
+            expect(termDescriptionField).toHaveValue("S24");
+            expect(termErrorField).toBeInTheDocument();
+            expect(termErrorField).toHaveValue("Error 1");
+
+            expect(submitButton).toHaveTextContent("Update");
+
+            fireEvent.change(nameField, { target: { value: 'UC Santa Barbara 2' } });
+            fireEvent.change(termRegexField, { target: { value: '[WSMF]\\e\\e' } });
+            fireEvent.change(termDescriptionField, { target: { value: 'W24' } });
+            fireEvent.change(termErrorField, { target: { value: 'Error 2' } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("School Updated - abbrev: ucsb name: UC Santa Barbara 2");
+
+            expect(mockNavigate).toBeCalledWith({ "to": "/schools" });
+
+            expect(axiosMock.history.put.length).toBe(1); 
+            expect(axiosMock.history.put[0].params).toEqual({ abbrev: 'ucsb' });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                name: "UC Santa Barbara 2",
+                termRegex: "[WSMF]\\e\\e",
+                termDescription: "W24",
+                termError: "Error 2" 
+            })); 
+
+
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <SchoolEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+
+            const abbrevField = screen.getByTestId("SchoolForm-abbrev");
+            const nameField = screen.getByTestId("SchoolForm-name");
+            const termRegexField = screen.getByTestId("SchoolForm-termRegex");
+            const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
+            const termErrorField = screen.getByTestId("SchoolForm-termError");
+            const submitButton = screen.getByTestId("SchoolForm-submit");
+
+
+            expect(abbrevField).toHaveValue("ucsb");
+            expect(nameField).toHaveValue("UC Santa Barbara");
+            expect(termRegexField).toHaveValue("[WSMF]\\d\\d");
+            expect(termDescriptionField).toHaveValue("S24");
+            expect(termErrorField).toHaveValue("Error 1");
+
+            fireEvent.change(nameField, { target: { value: 'UC Santa Barbara 2' } });
+            fireEvent.change(termRegexField, { target: { value: '[WSMF]\\e\\e' } });
+            fireEvent.change(termDescriptionField, { target: { value: 'W24' } });
+            fireEvent.change(termErrorField, { target: { value: 'Error 2' } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("School Updated - abbrev: ucsb name: UC Santa Barbara 2");
+            expect(mockNavigate).toBeCalledWith({ "to": "/schools" });
+        });
+
+
+    });
+});


### PR DESCRIPTION
In this PR, an edit button for schools that takes me to school edit page where I can edit schools was made.

This concludes the "EPIC: Frontend for Schools CRUD (some of which can be done in parallel)" issue. This frees me up to work on another issue if there are any that can be completed by Thursday before class. 

Deployed at: https://organic-nicoshinozaki-dev.dokku-10.cs.ucsb.edu

Closes #45 
Closes #5 